### PR TITLE
Update google_sign_in_all_platforms.dart

### DIFF
--- a/google_sign_in_all_platforms/lib/google_sign_in_all_platforms.dart
+++ b/google_sign_in_all_platforms/lib/google_sign_in_all_platforms.dart
@@ -13,10 +13,6 @@ class GoogleSignIn {
           (params.clientSecret != null && params.clientId != null) ||
               !isDesktop,
           'For Desktop, clientSecret and clientId cannot be null',
-        ),
-        assert(
-          params.clientId != null || !Platform.isAndroid,
-          'For Android, clientId cannot be null',
         ) {
     GoogleSignInAllPlatformsInterface.instance.init(params);
   }


### PR DESCRIPTION
For Android the client id isn't needed at all, as I have tested myself without it and as stated on https://pub.dev/packages/google_sign_in the clientId is optional.